### PR TITLE
'exec' and 'restart' commands should automatically start the server instead of crashing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.gem
 *.rbc
 /.config
+.vscode/
 /coverage/
 /InstalledFiles
 /pkg/

--- a/README.md
+++ b/README.md
@@ -58,8 +58,9 @@ Available commands:
 
 `rubocop-daemon-wrapper` is a bash script that talks to the `rubocop-daemon` server via `netcat`. This provides much lower latency than the `rubocop-daemon` Ruby script.
 
-Unfortunately `rubygems` will wrap any executables with a Ruby script, and [there is no way to disable this behavior](https://github.com/rubygems/rubygems/issues/88).
-You must manually download and install the bash script:
+For now, you have to manually download and install the bash script:
+
+> (`rubygems` will wrap any executable files with a Ruby script, and [you can't disable this behavior](https://github.com/rubygems/rubygems/issues/88).)
 
 ```
 curl https://raw.githubusercontent.com/fohte/rubocop-daemon/master/bin/rubocop-daemon-wrapper -o /tmp/rubocop-daemon-wrapper
@@ -73,26 +74,24 @@ You can then replace any calls to `rubocop` with `rubocop-daemon-wrapper`.
 rubocop-daemon-wrapper foo.rb bar.rb
 ```
 
-`rubocop-daemon-wrapper` will automatically start the daemon server if it is not already running.
+`rubocop-daemon-wrapper` will automatically start the daemon server if it is not already running. So the first call will be about the same as `rubocop`, but the second call will be much faster.
 
-To use `rubocop-daemon-wrapper` with the [VS Code RuboCop extension](https://github.com/misogi/vscode-ruby-rubocop), add a `rubocop` symlink in `/usr/local/bin`:
+## Use with VS Code
 
-```bash
-sudo ln -fs /usr/local/bin/rubocop-daemon-wrapper /usr/local/bin/rubocop
-```
+Unfortunately, the [vscode-ruby extension doesn't really allow you to customize the `rubocop` path or binary](https://github.com/rubyide/vscode-ruby/issues/413). (You can change the linter path, but not the formatter.)
 
-Unfortunately, the [vscode-ruby extension doesn't really allow you to customize the rubocop path or binary](https://github.com/rubyide/vscode-ruby/issues/413). (You can change the linter, but not the formatter.)
-
-So in the meantime, you might want to just override the rubocop binary with a symlink:
+In the meantime, you could just override the `rubocop` binary with a symlink to `rubocop-daemon-wrapper`:
 
 ```bash
+# Find your rubocop path
 $ which rubocop
 # => /Users/username/.rvm/gems/ruby-2.5.3/bin/rubocop
 
+# Override rubocop with a symlink to rubocop-daemon-wrapper
 $ ln -fs /usr/local/bin/rubocop-daemon-wrapper /Users/username/.rvm/gems/ruby-2.5.3/bin/rubocop
 ```
 
-Now VS Code will use the `rubocop-daemon-wrapper` script, and `formatOnSave` will be much faster (< 200ms instead of 3-5 seconds).
+Now VS Code will use the `rubocop-daemon-wrapper` script, and `formatOnSave` should be much faster (~150ms instead of 3-5 seconds).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -56,11 +56,32 @@ Available commands:
 
 ## More speed
 
-If you're really into performance and want the lowest possible latency, talk to the `rubocop-daemon` server with netcat:
+`rubocop-daemon-wrapper` is a bash script that talks to the `rubocop-daemon` server via netcat, and this provides the lowest possible latency.
 
-```sh
-echo "$(cat ~/.cache/rubocop-daemon/token) $PWD exec [rubocop-options]" | nc localhost $(cat ~/.cache/rubocop-daemon/port)
+Unfortunately `rubygems` will wrap any executables with a Ruby script, and [there is no way to disable this behavior](https://github.com/rubygems/rubygems/issues/88).
+So you must manually download and install this bash script:
+
 ```
+curl https://raw.githubusercontent.com/fohte/rubocop-daemon/master/bin/rubocop-daemon-wrapper -o /tmp/rubocop-daemon-wrapper
+sudo mv /tmp/rubocop-daemon-wrapper /usr/local/bin/rubocop-daemon-wrapper
+sudo chmod +x /usr/local/bin/rubocop-daemon-wrapper
+```
+
+You can then replace any calls to `rubocop` with `rubocop-daemon-wrapper`.
+
+```
+rubocop-daemon-wrapper foo.rb bar.rb
+```
+
+`rubocop-daemon-wrapper` will automatically start the daemon server if it is not already running.
+
+To use `rubocop-daemon-wrapper` with the [VS Code RuboCop extension](https://github.com/misogi/vscode-ruby-rubocop), add a `rubocop` symlink in `/usr/local/bin`:
+
+```bash
+sudo ln -fs /usr/local/bin/rubocop-daemon-wrapper /usr/local/bin/rubocop
+```
+
+Then set the `ruby.rubocop.executePath` option to `/usr/local/bin`. Now VS Code will use the `rubocop-daemon-wrapper` script, and `formatOnSave` will be much faster (< 200ms instead of 3-5 seconds).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ Available commands:
 
 ## More speed
 
-`rubocop-daemon-wrapper` is a bash script that talks to the `rubocop-daemon` server via netcat, and this provides the lowest possible latency.
+`rubocop-daemon-wrapper` is a bash script that talks to the `rubocop-daemon` server via `netcat`. This provides much lower latency than the `rubocop-daemon` Ruby script.
 
 Unfortunately `rubygems` will wrap any executables with a Ruby script, and [there is no way to disable this behavior](https://github.com/rubygems/rubygems/issues/88).
-So you must manually download and install this bash script:
+You must manually download and install the bash script:
 
 ```
 curl https://raw.githubusercontent.com/fohte/rubocop-daemon/master/bin/rubocop-daemon-wrapper -o /tmp/rubocop-daemon-wrapper

--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ rubocop-daemon <command>
 
 Available commands:
 
-* `start`: start the server
-* `stop`: stop the server
-* `status`: print out whether the server is currently running
-* `restart`: restart the server
-* `exec [file1, file2, ...] [-- [rubocop-options]]`: invoke `rubocop` with the given `rubocop-options`
+- `start`: start the server
+- `stop`: stop the server
+- `status`: print out whether the server is currently running
+- `restart`: restart the server
+- `exec [file1, file2, ...] [-- [rubocop-options]]`: invoke `rubocop` with the given `rubocop-options`
 
 ## More speed
 
@@ -81,7 +81,18 @@ To use `rubocop-daemon-wrapper` with the [VS Code RuboCop extension](https://git
 sudo ln -fs /usr/local/bin/rubocop-daemon-wrapper /usr/local/bin/rubocop
 ```
 
-Then set the `ruby.rubocop.executePath` option to `/usr/local/bin`. Now VS Code will use the `rubocop-daemon-wrapper` script, and `formatOnSave` will be much faster (< 200ms instead of 3-5 seconds).
+Unfortunately, the [vscode-ruby extension doesn't really allow you to customize the rubocop path or binary](https://github.com/rubyide/vscode-ruby/issues/413). (You can change the linter, but not the formatter.)
+
+So in the meantime, you might want to just override the rubocop binary with a symlink:
+
+```bash
+$ which rubocop
+# => /Users/username/.rvm/gems/ruby-2.5.3/bin/rubocop
+
+$ ln -fs /usr/local/bin/rubocop-daemon-wrapper /Users/username/.rvm/gems/ruby-2.5.3/bin/rubocop
+```
+
+Now VS Code will use the `rubocop-daemon-wrapper` script, and `formatOnSave` will be much faster (< 200ms instead of 3-5 seconds).
 
 ## Contributing
 

--- a/bin/rubocop-daemon-wrapper
+++ b/bin/rubocop-daemon-wrapper
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+CACHE_BASE_DIR="$HOME/.cache/rubocop-daemon"
+CACHE_KEY="$(echo ${PWD:1} | tr '/' '+')"
+CACHE_DIR="$CACHE_BASE_DIR/$CACHE_KEY"
+TOKEN_PATH="$CACHE_DIR/token"
+PORT_PATH="$CACHE_DIR/port"
+if [ ! -f "$TOKEN_PATH" ]; then
+  echo "rubocop-daemon: server is not running. Starting..." >&2
+  rubocop-daemon start
+fi
+
+TOKEN="$(cat "$TOKEN_PATH")"
+PORT="$(cat "$PORT_PATH")"
+echo "$TOKEN $PWD exec $@" | nc localhost "$PORT"

--- a/bin/rubocop-daemon-wrapper
+++ b/bin/rubocop-daemon-wrapper
@@ -25,6 +25,24 @@ if [ ! -f "$TOKEN_PATH" ]; then
   rubocop-daemon start
 fi
 
-TOKEN="$(cat "$TOKEN_PATH")"
-PORT="$(cat "$PORT_PATH")"
-echo "$TOKEN $PWD exec $@" | nc localhost "$PORT"
+run_rubocop_command() {
+  TOKEN="$(cat "$TOKEN_PATH")"
+  PORT="$(cat "$PORT_PATH")"
+  COMMAND="$TOKEN $PWD exec $@"
+  echo "$COMMAND" | nc localhost "$PORT"
+}
+
+if ! run_rubocop_command $@; then
+  echo "Error sending command to localhost:$PORT ($COMMAND)" >&2
+  echo "Killing all rubocop-daemon processes and removing cache directory..." >&2
+  pkill "rubocop-daemon start"
+  rm -rf "$CACHE_DIR"
+  echo "Starting new rubocop-daemon server..." >&2
+  rubocop-daemon start
+  if ! run_rubocop_command $@; then
+    echo "Sorry, something went wrong with rubocop-daemon!" >&2
+    echo "Please try updating the gem or re-installing the rubocop-daemon-wrapper script."
+    echo "If that doesn't work, please open an issue on GitHub:" \
+      "https://github.com/fohte/rubocop-daemon/issues/new" >&2
+  fi
+fi

--- a/bin/rubocop-daemon-wrapper
+++ b/bin/rubocop-daemon-wrapper
@@ -1,11 +1,25 @@
 #!/bin/bash
 set -e
 
-CACHE_BASE_DIR="$HOME/.cache/rubocop-daemon"
-CACHE_KEY="$(echo ${PWD:1} | tr '/' '+')"
-CACHE_DIR="$CACHE_BASE_DIR/$CACHE_KEY"
-TOKEN_PATH="$CACHE_DIR/token"
-PORT_PATH="$CACHE_DIR/port"
+find_project_root() {
+  path=$(pwd)
+  while [[ "$path" != "" && ! -f "$path/Gemfile" && ! -f "$path/gems.rb" ]]; do
+    path=${path%/*}
+  done
+  echo "$path"
+}
+
+PROJECT_ROOT="$(find_project_root)"
+if [ -z "$PROJECT_ROOT" ]; then
+  echo "Could not find Gemfile or gems.rb in $PWD or any parent directories!" >&2
+  exit 1
+fi
+
+CACHE_DIR="$HOME/.cache/rubocop-daemon"
+PROJECT_CACHE_KEY="$(echo ${PROJECT_ROOT:1} | tr '/' '+')"
+PROJECT_CACHE_DIR="$CACHE_DIR/$PROJECT_CACHE_KEY"
+TOKEN_PATH="$PROJECT_CACHE_DIR/token"
+PORT_PATH="$PROJECT_CACHE_DIR/port"
 if [ ! -f "$TOKEN_PATH" ]; then
   echo "rubocop-daemon: server is not running. Starting..." >&2
   rubocop-daemon start

--- a/bin/rubocop-daemon-wrapper
+++ b/bin/rubocop-daemon-wrapper
@@ -31,8 +31,14 @@ run_rubocop_command() {
   TOKEN="$(cat "$TOKEN_PATH")"
   PORT="$(cat "$PORT_PATH")"
   COMMAND="$TOKEN $PWD exec $@"
+  rm -f "$STATUS_PATH" # Clear the previous status
   if echo "$COMMAND" | nc localhost "$PORT"; then
-    exit "$(cat $STATUS_PATH)"
+    if [ -f "$STATUS_PATH" ]; then
+      exit "$(cat $STATUS_PATH)"
+    else
+      echo "rubocop-daemon: server did not write status to $STATUS_PATH!" >&2
+      exit 1
+    fi
   fi
   return 1
 }

--- a/bin/rubocop-daemon-wrapper
+++ b/bin/rubocop-daemon-wrapper
@@ -40,7 +40,7 @@ run_rubocop_command() {
 if ! run_rubocop_command $@; then
   echo "Error sending command to localhost:$PORT ($COMMAND)" >&2
   echo "Killing all rubocop-daemon processes and removing cache directory..." >&2
-  pkill "rubocop-daemon start"
+  pkill "rubocop-daemon "
   rm -rf "$CACHE_DIR"
   echo "Starting new rubocop-daemon server..." >&2
   rubocop-daemon start

--- a/bin/rubocop-daemon-wrapper
+++ b/bin/rubocop-daemon-wrapper
@@ -54,7 +54,7 @@ if ! run_rubocop_command $@; then
   echo "rubocop-daemon-wrapper: Error sending command to localhost:$PORT ($COMMAND)" >&2
   echo "Killing all rubocop-daemon processes and removing cache directory..." >&2
   rm -rf "$CACHE_DIR"
-  pkill "rubocop-daemon "
+  pkill -f "rubocop-daemon (re)?start"
   echo "Starting new rubocop-daemon server..." >&2
   rubocop-daemon start
   if ! run_rubocop_command $@; then

--- a/bin/rubocop-daemon-wrapper
+++ b/bin/rubocop-daemon-wrapper
@@ -20,6 +20,8 @@ PROJECT_CACHE_KEY="$(echo ${PROJECT_ROOT:1} | tr '/' '+')"
 PROJECT_CACHE_DIR="$CACHE_DIR/$PROJECT_CACHE_KEY"
 TOKEN_PATH="$PROJECT_CACHE_DIR/token"
 PORT_PATH="$PROJECT_CACHE_DIR/port"
+STATUS_PATH="$PROJECT_CACHE_DIR/status"
+
 if [ ! -f "$TOKEN_PATH" ]; then
   echo "rubocop-daemon: server is not running. Starting..." >&2
   rubocop-daemon start
@@ -29,7 +31,10 @@ run_rubocop_command() {
   TOKEN="$(cat "$TOKEN_PATH")"
   PORT="$(cat "$PORT_PATH")"
   COMMAND="$TOKEN $PWD exec $@"
-  echo "$COMMAND" | nc localhost "$PORT"
+  if echo "$COMMAND" | nc localhost "$PORT"; then
+    exit "$(cat $STATUS_PATH)"
+  fi
+  return 1
 }
 
 if ! run_rubocop_command $@; then

--- a/bin/rubocop-daemon-wrapper
+++ b/bin/rubocop-daemon-wrapper
@@ -2,7 +2,7 @@
 set -e
 
 find_project_root() {
-  path=$(pwd)
+  path=$(pwd -P)
   while [[ "$path" != "" && ! -f "$path/Gemfile" && ! -f "$path/gems.rb" ]]; do
     path=${path%/*}
   done
@@ -11,8 +11,8 @@ find_project_root() {
 
 PROJECT_ROOT="$(find_project_root)"
 if [ -z "$PROJECT_ROOT" ]; then
-  echo "Could not find Gemfile or gems.rb in $PWD or any parent directories!" >&2
-  exit 1
+  # If we can't find a Gemfile, just use the current directory
+  PROJECT_ROOT="$(pwd -P)"
 fi
 
 CACHE_DIR="$HOME/.cache/rubocop-daemon"
@@ -37,7 +37,7 @@ fi
 run_rubocop_command() {
   TOKEN="$(cat "$TOKEN_PATH")"
   PORT="$(cat "$PORT_PATH")"
-  COMMAND="$TOKEN $PWD exec $@"
+  COMMAND="$TOKEN $PROJECT_ROOT exec $@"
   rm -f "$STATUS_PATH" # Clear the previous status
   if echo -e "$COMMAND${STDIN_CONTENT}" | nc localhost "$PORT"; then
     if [ -f "$STATUS_PATH" ]; then

--- a/bin/rubocop-daemon-wrapper
+++ b/bin/rubocop-daemon-wrapper
@@ -20,10 +20,17 @@ PROJECT_CACHE_KEY="$(echo ${PROJECT_ROOT:1} | tr '/' '+')"
 PROJECT_CACHE_DIR="$CACHE_DIR/$PROJECT_CACHE_KEY"
 TOKEN_PATH="$PROJECT_CACHE_DIR/token"
 PORT_PATH="$PROJECT_CACHE_DIR/port"
+STDIN_PATH="$PROJECT_CACHE_DIR/stdin"
 STATUS_PATH="$PROJECT_CACHE_DIR/status"
 
+# If -s or --stdin args are present, read stdin with `cat`
+for ARG in $@; do
+  if [ -z "$STDIN_CONTENT" ] && [ "$ARG" == "--stdin" ] || [ "$ARG" == "-s" ]; then
+    STDIN_CONTENT="\n$(cat)"
+  fi
+done
+
 if [ ! -f "$TOKEN_PATH" ]; then
-  echo "rubocop-daemon: server is not running. Starting..." >&2
   rubocop-daemon start
 fi
 
@@ -32,11 +39,11 @@ run_rubocop_command() {
   PORT="$(cat "$PORT_PATH")"
   COMMAND="$TOKEN $PWD exec $@"
   rm -f "$STATUS_PATH" # Clear the previous status
-  if echo "$COMMAND" | nc localhost "$PORT"; then
+  if echo -e "$COMMAND${STDIN_CONTENT}" | nc localhost "$PORT"; then
     if [ -f "$STATUS_PATH" ]; then
       exit "$(cat $STATUS_PATH)"
     else
-      echo "rubocop-daemon: server did not write status to $STATUS_PATH!" >&2
+      echo "rubocop-daemon-wrapper: server did not write status to $STATUS_PATH!" >&2
       exit 1
     fi
   fi
@@ -44,10 +51,10 @@ run_rubocop_command() {
 }
 
 if ! run_rubocop_command $@; then
-  echo "Error sending command to localhost:$PORT ($COMMAND)" >&2
+  echo "rubocop-daemon-wrapper: Error sending command to localhost:$PORT ($COMMAND)" >&2
   echo "Killing all rubocop-daemon processes and removing cache directory..." >&2
-  pkill "rubocop-daemon "
   rm -rf "$CACHE_DIR"
+  pkill "rubocop-daemon "
   echo "Starting new rubocop-daemon server..." >&2
   rubocop-daemon start
   if ! run_rubocop_command $@; then

--- a/lib/rubocop/daemon.rb
+++ b/lib/rubocop/daemon.rb
@@ -2,6 +2,8 @@
 
 module RuboCop
   module Daemon
+    TIMEOUT = 20
+
     autoload :VERSION, 'rubocop/daemon/version'
 
     autoload :CLI, 'rubocop/daemon/cli'
@@ -14,6 +16,17 @@ module RuboCop
 
     def self.running?
       Cache.dir.exist? && Cache.pid_path.file? && Cache.pid_running?
+    end
+
+    def self.wait_for_running_status!(expected)
+      start_time = Time.now
+      while Daemon.running? != expected
+        sleep 0.1
+        next unless Time.now - start_time > TIMEOUT
+
+        warn "running? was not #{expected} after #{TIMEOUT} seconds!"
+        exit 1
+      end
     end
   end
 end

--- a/lib/rubocop/daemon/cache.rb
+++ b/lib/rubocop/daemon/cache.rb
@@ -62,7 +62,7 @@ module RuboCop
         def acquire_lock
           lock_file = File.open(lock_path, File::CREAT)
           flock_result = lock_file.flock(File::LOCK_EX | File::LOCK_NB)
-          yield flock_result == 0
+          yield flock_result.zero?
         ensure
           lock_file.flock(File::LOCK_UN)
           lock_file.close

--- a/lib/rubocop/daemon/cache.rb
+++ b/lib/rubocop/daemon/cache.rb
@@ -16,10 +16,8 @@ module RuboCop
 
             current_dir = File.expand_path('..', current_dir)
           end
-
-          raise GemfileNotFound,
-                "Could not find Gemfile or gems.rb in #{Dir.pwd} " \
-                'or any parent directories!'
+          # If we can't find a Gemfile, just use the current directory
+          Dir.pwd
         end
 
         def project_dir_cache_key

--- a/lib/rubocop/daemon/cache.rb
+++ b/lib/rubocop/daemon/cache.rb
@@ -45,6 +45,10 @@ module RuboCop
           dir.join('pid')
         end
 
+        def status_path
+          dir.join('status')
+        end
+
         def pid_running?
           Process.kill 0, pid_path.read.to_i
         rescue Errno::ESRCH
@@ -61,6 +65,10 @@ module RuboCop
           yield
         ensure
           dir.rmtree
+        end
+
+        def write_status_file(status)
+          status_path.write(status)
         end
       end
     end

--- a/lib/rubocop/daemon/cache.rb
+++ b/lib/rubocop/daemon/cache.rb
@@ -29,9 +29,12 @@ module RuboCop
         false
       end
 
-      def self.make_server_file(port:, token:)
+      def self.write_port_and_token_files(port:, token:)
         port_path.write(port)
         token_path.write(token)
+      end
+
+      def self.write_pid_file
         pid_path.write(Process.pid)
         yield
       ensure

--- a/lib/rubocop/daemon/cli.rb
+++ b/lib/rubocop/daemon/cli.rb
@@ -23,9 +23,6 @@ module RuboCop
       rescue UnknownClientCommandError => e
         warn "rubocop-daemon: #{e.message}. See 'rubocop-daemon --help'."
         exit 1
-      rescue ServerIsNotRunningError
-        warn 'rubocop-daemon: server is not running.'
-        exit 1
       end
 
       def parser

--- a/lib/rubocop/daemon/client_command/base.rb
+++ b/lib/rubocop/daemon/client_command/base.rb
@@ -25,8 +25,16 @@ module RuboCop
           end
         end
 
-        def check_running_server!
-          raise ServerIsNotRunningError unless Daemon.running?
+        def check_running_server
+          Daemon.running?.tap do |running|
+            warn 'rubocop-daemon: server is not running.' unless running
+          end
+        end
+
+        def ensure_server!
+          return if check_running_server
+
+          ClientCommand::Start.new([]).run
         end
       end
     end

--- a/lib/rubocop/daemon/client_command/exec.rb
+++ b/lib/rubocop/daemon/client_command/exec.rb
@@ -12,6 +12,7 @@ module RuboCop
             args: args,
             body: $stdin.tty? ? '' : $stdin.read,
           )
+          exit_with_status!
         end
 
         private
@@ -20,6 +21,15 @@ module RuboCop
           @parser ||= CLI.new_parser do |p|
             p.banner = 'usage: rubocop-daemon exec [options] [files...] [-- [rubocop-options]]'
           end
+        end
+
+        def exit_with_status!
+          raise "rubocop-daemon: Could not find status file at: #{Cache.status_path}" unless Cache.status_path.file?
+
+          status = Cache.status_path.read
+          raise "rubocop-daemon: '#{status}' is not a valid status!" unless status.match?(/^\d+$/)
+
+          exit status.to_i
         end
       end
     end

--- a/lib/rubocop/daemon/client_command/exec.rb
+++ b/lib/rubocop/daemon/client_command/exec.rb
@@ -6,7 +6,7 @@ module RuboCop
       class Exec < Base
         def run
           args = parser.parse(@argv)
-          check_running_server!
+          ensure_server!
           send_request(
             command: 'exec',
             args: args,

--- a/lib/rubocop/daemon/client_command/exec.rb
+++ b/lib/rubocop/daemon/client_command/exec.rb
@@ -7,6 +7,7 @@ module RuboCop
         def run
           args = parser.parse(@argv)
           ensure_server!
+          Cache.status_path.delete if Cache.status_path.file?
           send_request(
             command: 'exec',
             args: args,

--- a/lib/rubocop/daemon/client_command/restart.rb
+++ b/lib/rubocop/daemon/client_command/restart.rb
@@ -6,9 +6,8 @@ module RuboCop
       class Restart < Base
         def run
           parser.parse(@argv)
-          check_running_server!
-          send_request(command: 'stop')
-          Server.new.start(@options.fetch(:port, 0))
+          send_request(command: 'stop') if check_running_server
+          Server.new(@options.fetch(:no_daemon, false)).start(@options.fetch(:port, 0))
         end
 
         private

--- a/lib/rubocop/daemon/client_command/restart.rb
+++ b/lib/rubocop/daemon/client_command/restart.rb
@@ -6,8 +6,9 @@ module RuboCop
       class Restart < Base
         def run
           parser.parse(@argv)
-          send_request(command: 'stop') if check_running_server
-          Server.new(@options.fetch(:no_daemon, false)).start(@options.fetch(:port, 0))
+
+          ClientCommand::Stop.new([]).run
+          ClientCommand::Start.new(@argv).run
         end
 
         private

--- a/lib/rubocop/daemon/client_command/start.rb
+++ b/lib/rubocop/daemon/client_command/start.rb
@@ -5,6 +5,11 @@ module RuboCop
     module ClientCommand
       class Start < Base
         def run
+          if Daemon.running?
+            warn 'rubocop-daemon: server is already running.'
+            return
+          end
+
           parser.parse(@argv)
           Server.new(@options.fetch(:no_daemon, false)).start(@options.fetch(:port, 0))
         end

--- a/lib/rubocop/daemon/client_command/stop.rb
+++ b/lib/rubocop/daemon/client_command/stop.rb
@@ -4,11 +4,22 @@ module RuboCop
   module Daemon
     module ClientCommand
       class Stop < Base
+        TIMEOUT = 10
+
         def run
           return unless check_running_server
 
           parser.parse(@argv)
           send_request(command: 'stop')
+
+          start_time = Time.now
+          while Daemon.running?
+            sleep 0.1
+            if Time.now - start_time > TIMEOUT
+              warn "rubocop-daemon was still running after #{TIMEOUT} seconds!"
+              exit 1
+            end
+          end
         end
 
         private

--- a/lib/rubocop/daemon/client_command/stop.rb
+++ b/lib/rubocop/daemon/client_command/stop.rb
@@ -4,22 +4,12 @@ module RuboCop
   module Daemon
     module ClientCommand
       class Stop < Base
-        TIMEOUT = 10
-
         def run
           return unless check_running_server
 
           parser.parse(@argv)
           send_request(command: 'stop')
-
-          start_time = Time.now
-          while Daemon.running?
-            sleep 0.1
-            if Time.now - start_time > TIMEOUT
-              warn "rubocop-daemon was still running after #{TIMEOUT} seconds!"
-              exit 1
-            end
-          end
+          Daemon.wait_for_running_status!(false)
         end
 
         private

--- a/lib/rubocop/daemon/client_command/stop.rb
+++ b/lib/rubocop/daemon/client_command/stop.rb
@@ -5,8 +5,9 @@ module RuboCop
     module ClientCommand
       class Stop < Base
         def run
+          return unless check_running_server
+
           parser.parse(@argv)
-          check_running_server!
           send_request(command: 'stop')
         end
 

--- a/lib/rubocop/daemon/errors.rb
+++ b/lib/rubocop/daemon/errors.rb
@@ -2,6 +2,7 @@
 
 module RuboCop
   module Daemon
+    class GemfileNotFound < StandardError; end
     class InvalidTokenError < StandardError; end
     class ServerStopRequest < StandardError; end
     class UnknownClientCommandError < StandardError; end

--- a/lib/rubocop/daemon/errors.rb
+++ b/lib/rubocop/daemon/errors.rb
@@ -3,7 +3,6 @@
 module RuboCop
   module Daemon
     class InvalidTokenError < StandardError; end
-    class ServerIsNotRunningError < StandardError; end
     class ServerStopRequest < StandardError; end
     class UnknownClientCommandError < StandardError; end
     class UnknownServerCommandError < StandardError; end

--- a/lib/rubocop/daemon/server.rb
+++ b/lib/rubocop/daemon/server.rb
@@ -24,8 +24,9 @@ module RuboCop
       def start(port)
         require 'rubocop'
         start_server(port)
+        Cache.write_port_and_token_files(port: @server.addr[1], token: token)
         Process.daemon(true) unless verbose
-        Cache.make_server_file(port: @server.addr[1], token: token) do
+        Cache.write_pid_file do
           read_socket(@server.accept) until @server.closed?
         end
       end

--- a/lib/rubocop/daemon/server_command/exec.rb
+++ b/lib/rubocop/daemon/server_command/exec.rb
@@ -5,6 +5,7 @@ module RuboCop
     module ServerCommand
       class Exec < Base
         def run
+          Cache.status_path.delete if Cache.status_path.file?
           # RuboCop output is colorized by default where there is a TTY.
           # We must pass the --color option to preserve this behavior.
           @args.unshift('--color') unless %w[--color --no-color].any? { |f| @args.include?(f) }

--- a/lib/rubocop/daemon/server_command/exec.rb
+++ b/lib/rubocop/daemon/server_command/exec.rb
@@ -5,6 +5,12 @@ module RuboCop
     module ServerCommand
       class Exec < Base
         def run
+          # RuboCop output is colorized by default where there is a TTY.
+          # We must pass the --color option to preserve this behavior.
+          unless %w[--color --no-color].any? { |f| @args.include?(f) }
+            @args.unshift('--color')
+          end
+
           RuboCop::CLI.new.run(@args)
         rescue SystemExit # rubocop:disable Lint/HandleExceptions
         end

--- a/lib/rubocop/daemon/socket_reader.rb
+++ b/lib/rubocop/daemon/socket_reader.rb
@@ -26,8 +26,12 @@ module RuboCop
       private
 
       def parse_request(content)
-        puts content if @verbose
         raw_header, *body = content.lines
+        if @verbose
+          puts raw_header.to_s
+          puts "STDIN: #{body.size} lines" if body.any?
+        end
+
         Request.new(parse_header(raw_header), body.join)
       end
 

--- a/rubocop-daemon.gemspec
+++ b/rubocop-daemon.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.16'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'pry-byebug', '~> 3.6.0'
 end

--- a/rubocop-daemon.gemspec
+++ b/rubocop-daemon.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rubocop'
 
   spec.add_development_dependency 'bundler', '~> 1.16'
+  spec.add_development_dependency 'pry-byebug', '~> 3.6.0'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'pry-byebug', '~> 3.6.0'
 end


### PR DESCRIPTION
I think it's more common to do it this way, and it makes it more user-friendly. It's much better when you don't have to remember to start the server manually, because this makes it easier to integrate `rubocop-daemon` with a text editor (e.g. VS Code) or command-line shortcuts / automated linting.

Fixes #2 