### PR TITLE
update to use `=~` to support older versions of ruby (<2.4)

### DIFF
--- a/lib/rubocop/daemon/client_command/exec.rb
+++ b/lib/rubocop/daemon/client_command/exec.rb
@@ -28,7 +28,7 @@ module RuboCop
           raise "rubocop-daemon: Could not find status file at: #{Cache.status_path}" unless Cache.status_path.file?
 
           status = Cache.status_path.read
-          raise "rubocop-daemon: '#{status}' is not a valid status!" unless status.match?(/^\d+$/)
+          raise "rubocop-daemon: '#{status}' is not a valid status!" if (status =~ /^\d+$/).nil?
 
           exit status.to_i
         end


### PR DESCRIPTION
Running an older version of Ruby produces the following error
```
bundler: failed to load command: rubocop-daemon (/Users/username/.rbenv/versions/2.2.8/bin/rubocop-daemon)
NoMethodError: undefined method `match?' for "1":String
  /Users/username/.rbenv/versions/2.2.8/lib/ruby/gems/2.2.0/gems/rubocop-daemon-0.3.1/lib/rubocop/daemon/client_command/exec.rb:31:in `exit_with_status!'
  /Users/username/.rbenv/versions/2.2.8/lib/ruby/gems/2.2.0/gems/rubocop-daemon-0.3.1/lib/rubocop/daemon/client_command/exec.rb:16:in `run'
  /Users/username/.rbenv/versions/2.2.8/lib/ruby/gems/2.2.0/gems/rubocop-daemon-0.3.1/lib/rubocop/daemon/cli.rb:38:in `create_subcommand_instance'
  /Users/username/.rbenv/versions/2.2.8/lib/ruby/gems/2.2.0/gems/rubocop-daemon-0.3.1/lib/rubocop/daemon/cli.rb:19:in `run'
  /Users/username/.rbenv/versions/2.2.8/lib/ruby/gems/2.2.0/gems/rubocop-daemon-0.3.1/exe/rubocop-daemon:8:in `<top (required)>'
  /Users/username/.rbenv/versions/2.2.8/bin/rubocop-daemon:23:in `load'
  /Users/username/.rbenv/versions/2.2.8/bin/rubocop-daemon:23:in `<top (required)>'
```

`.match?` was added in Ruby2.4 (https://www.ruby-lang.org/en/news/2016/12/25/ruby-2-4-0-released/)

This is the only place where an exclusive Ruby 2.4+ method is used

With this change, the gem works as expected on older versions. Confirmed on 2.2, 2.3 and it continues to work on 2.4+