### PR TITLE
Remove "rubocop-daemon is processing a request" warning

### DIFF
--- a/bin/rubocop-daemon-wrapper
+++ b/bin/rubocop-daemon-wrapper
@@ -68,7 +68,7 @@ RUBOCOP_DAEMON="$COMMAND_PREFIX rubocop-daemon"
 # If a lock file exist, wait up to 5 seconds.
 i=0
 while [ -d "$LOCK_PATH" ]; do
-  echo "rubocop-daemon-wrapper: rubocop-daemon is processing a request; pausing before trying again..." >&2
+  # rubocop-daemon is already processing a request. Pause before trying again...
   sleep 1
   i=$((i + 1))
   if [ $i -ge 5 ]; then


### PR DESCRIPTION
This causes this warning to appear in VS Code:

<img width="472" alt="Screen Shot 2020-04-14 at 8 13 36 PM" src="https://user-images.githubusercontent.com/139536/79223952-dd354b00-7e8c-11ea-9a74-ecdd515d1505.png">

This happens quite regularly so it would be better to silently ignore this case, and only show a warning if it times out after 5 seconds.