### PR TITLE
Add a option to expose daemon's TCP port

### DIFF
--- a/lib/rubocop/daemon/client_command/start.rb
+++ b/lib/rubocop/daemon/client_command/start.rb
@@ -19,7 +19,10 @@ module RuboCop
             end
 
             parser.parse(@argv)
-            Server.new(@options.fetch(:no_daemon, false)).start(@options.fetch(:port, 0))
+            Server.new(@options.fetch(:no_daemon, false)).start(
+              @options.fetch(:host, '127.0.0.1'),
+              @options.fetch(:port, 0),
+            )
           end
         end
 
@@ -30,6 +33,7 @@ module RuboCop
             p.banner = 'usage: rubocop-daemon start [options]'
 
             p.on('-p', '--port [PORT]') { |v| @options[:port] = v }
+            p.on('-b', '--binding [IP]') { |v| @options[:host] = v }
             p.on('--no-daemon', 'Starts server in foreground with debug information') { @options[:no_daemon] = true }
           end
         end

--- a/lib/rubocop/daemon/server.rb
+++ b/lib/rubocop/daemon/server.rb
@@ -21,9 +21,9 @@ module RuboCop
         self.class.token
       end
 
-      def start(port)
+      def start(host, port)
         require 'rubocop'
-        start_server(port)
+        start_server(host, port)
         Cache.write_port_and_token_files(port: @server.addr[1], token: token)
         Process.daemon(true) unless verbose
         Cache.write_pid_file do
@@ -33,9 +33,9 @@ module RuboCop
 
       private
 
-      def start_server(port)
-        @server = TCPServer.open('127.0.0.1', port)
-        puts "Server listen on port #{@server.addr[1]}" if verbose
+      def start_server(host, port)
+        @server = TCPServer.open(host, port)
+        puts "Server listen on #{@server.addr[3]}:#{@server.addr[1]}" if verbose
       end
 
       def read_socket(socket)


### PR DESCRIPTION
The gem's idea is great, but it can't be used from remote environments (for example, from docker),
because it can't expose TCP port.

This pull-request is to add a option for exposing TCP port to external.
I suppose that, rubocop-daemon run as docker container and user use rubocop-daemon-wrapper on host machine.

The option name, `--binding`, is from same feature of `rails new`.
But I'm not particular about the option name, so it's ok to rename it.
