### PR TITLE
use COMMAND_PREFIX when searching for rubocop-daemon

### DIFF
--- a/bin/rubocop-daemon-wrapper
+++ b/bin/rubocop-daemon-wrapper
@@ -8,7 +8,7 @@ if [ -n "$RUBOCOP_DAEMON_USE_BUNDLER" ]; then
   COMMAND_PREFIX="bundle exec"
 fi
 
-if ! command -v rubocop-daemon > /dev/null; then
+if ! command -v $COMMAND_PREFIX rubocop-daemon > /dev/null; then
   $COMMAND_PREFIX rubocop $@
   exit $?
 fi


### PR DESCRIPTION
if `RUBOCOP_DAEMON_USE_BUNDLER` is set we need to use bundler when we check if `rubocop-daemon` exists.