### PR TITLE
Support both older and newer versions of Netcat

### DIFF
--- a/bin/rubocop-daemon-wrapper
+++ b/bin/rubocop-daemon-wrapper
@@ -17,7 +17,11 @@ if [[ "$OSTYPE" == "linux-gnu" ]]; then
   if [ -f "/etc/fedora-release" ]; then
     NETCAT_CMD="nc"
   else
-    NETCAT_CMD="nc -N"
+    if nc -h 2>&1 | grep -q -- '\s-N\s'; then
+      NETCAT_CMD="nc -N"
+    else
+      NETCAT_CMD="nc"
+    fi
   fi
 elif [[ "$OSTYPE" == "darwin"* ]]; then
   NETCAT_CMD="nc"


### PR DESCRIPTION
Hello. On Ubuntu 16.04, `nc` doesn't have a `-N` parameter. But on 20.04, it seem to have it. Both land in the same `if` of the daemon-wrapper script.

This PR does a grep in the output of `nc -h` to check if there is a parameter named `-N` or not, and use the command based on it.

This could possibly replace the whole list of ifs, but that's not something I can verify. I just know that in the case where we don't really know what the OS is, making an educated guess seems like a better idea than just forcing one of the two choice.

Regards, and thanks for this project!

