### PR TITLE
Add RUBOCOP_DAEMON_RUBOCOP_VERSION to rubocop-daemon-wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,18 @@ $ export RUBOCOP_DAEMON_USE_BUNDLER=true
 
 Now `rubocop-daemon-wrapper` will call the `rubocop-daemon` command with `bundle exec`.
 
+### Use with a specific version of RuboCop
+
+If you have multiple versions of RuboCop installed, you can set `RUBOCOP_DAEMON_RUBOCOP_VERSION` environment variable to the specific version you want `rubocop-daemon` to use:
+
+```console
+$ export RUBOCOP_DAEMON_RUBOCOP_VERSION=x.y.z
+```
+
+Now `rubocop-daemon-wrapper` will start `rubocop-daemon` with the specified version.
+
+> (Make sure you stop the server if it's already running before setting this environment variable.)
+
 ### Use with VS Code
 
 Unfortunately, the [vscode-ruby extension doesn't really allow you to customize the `rubocop` path or binary](https://github.com/rubyide/vscode-ruby/issues/413). (You can change the linter path, but not the formatter.)

--- a/bin/rubocop-daemon-wrapper
+++ b/bin/rubocop-daemon-wrapper
@@ -8,6 +8,12 @@ if [ -n "$RUBOCOP_DAEMON_USE_BUNDLER" ]; then
   COMMAND_PREFIX="bundle exec"
 fi
 
+RUBOCOP_DAEMON_OPTS=""
+
+if [ -n "$RUBOCOP_DAEMON_RUBOCOP_VERSION" ]; then
+  RUBOCOP_DAEMON_OPTS="--rubocop-version $RUBOCOP_DAEMON_RUBOCOP_VERSION"
+fi
+
 if ! command -v rubocop-daemon > /dev/null; then
   $COMMAND_PREFIX rubocop $@
   exit $?
@@ -97,7 +103,7 @@ for ARG in $@; do
 done
 
 if [ ! -f "$TOKEN_PATH" ]; then
-  $RUBOCOP_DAEMON start
+  $RUBOCOP_DAEMON start $RUBOCOP_DAEMON_OPTS
 fi
 
 run_rubocop_command() {
@@ -122,7 +128,7 @@ if ! run_rubocop_command $@; then
   rm -rf "$CACHE_DIR"
   pkill -f "rubocop-daemon (re)?start"
   echo "Starting new rubocop-daemon server..." >&2
-  $RUBOCOP_DAEMON start
+  $RUBOCOP_DAEMON start $RUBOCOP_DAEMON_OPTS
   if ! run_rubocop_command $@; then
     echo "Sorry, something went wrong with rubocop-daemon!" >&2
     echo "Please try updating the gem or re-installing the rubocop-daemon-wrapper script."

--- a/lib/rubocop/daemon/cli.rb
+++ b/lib/rubocop/daemon/cli.rb
@@ -17,7 +17,7 @@ module RuboCop
         return if argv.empty?
 
         create_subcommand_instance(argv)
-      rescue OptionParser::InvalidOption => e
+      rescue OptionParser::InvalidOption, InvalidRuboCopVersionError => e
         warn "error: #{e.message}"
         exit 1
       rescue UnknownClientCommandError => e

--- a/lib/rubocop/daemon/client_command/start.rb
+++ b/lib/rubocop/daemon/client_command/start.rb
@@ -19,7 +19,7 @@ module RuboCop
             end
 
             parser.parse(@argv)
-            Server.new(@options.fetch(:no_daemon, false)).start(@options.fetch(:port, 0))
+            Server.new(@options.fetch(:no_daemon, false)).start(@options.fetch(:port, 0), @options.fetch(:rubocop_version, nil))
           end
         end
 
@@ -31,6 +31,7 @@ module RuboCop
 
             p.on('-p', '--port [PORT]') { |v| @options[:port] = v }
             p.on('--no-daemon', 'Starts server in foreground with debug information') { @options[:no_daemon] = true }
+            p.on('--rubocop-version [VERSION]', 'The version of rubocop to use.') { |v| @options[:rubocop_version] = v }
           end
         end
       end

--- a/lib/rubocop/daemon/errors.rb
+++ b/lib/rubocop/daemon/errors.rb
@@ -7,5 +7,6 @@ module RuboCop
     class ServerStopRequest < StandardError; end
     class UnknownClientCommandError < StandardError; end
     class UnknownServerCommandError < StandardError; end
+    class InvalidRuboCopVersionError < StandardError; end
   end
 end


### PR DESCRIPTION
Add the ability to specify a `rubocop` version when running the daemon using the `RUBOCOP_DAEMON_RUBOCOP_VERSION` environment variable. This resolves the issue in case, for example, two versions of `rubocop` are installed and the active project requires the older version to be used.