### PR TITLE
Add --allow-external-access flag

### DIFF
--- a/lib/rubocop/daemon/client_command/start.rb
+++ b/lib/rubocop/daemon/client_command/start.rb
@@ -19,7 +19,11 @@ module RuboCop
             end
 
             parser.parse(@argv)
-            Server.new(@options.fetch(:no_daemon, false)).start(@options.fetch(:port, 0))
+
+            Server.new(@options.fetch(:no_daemon, false)).start(
+              port: @options.fetch(:port, 0),
+              allow_external_access: @options.fetch(:allow_external_access, false)
+            )
           end
         end
 
@@ -31,6 +35,9 @@ module RuboCop
 
             p.on('-p', '--port [PORT]') { |v| @options[:port] = v }
             p.on('--no-daemon', 'Starts server in foreground with debug information') { @options[:no_daemon] = true }
+            p.on('--allow-external-access', 'Allows other IPs to access the daemon') do
+              @options[:allow_external_access] = true
+            end
           end
         end
       end

--- a/lib/rubocop/daemon/server.rb
+++ b/lib/rubocop/daemon/server.rb
@@ -21,9 +21,9 @@ module RuboCop
         self.class.token
       end
 
-      def start(port)
+      def start(port:, allow_external_access: false)
         require 'rubocop'
-        start_server(port)
+        start_server(port: port, allow_external_access: allow_external_access)
         Cache.write_port_and_token_files(port: @server.addr[1], token: token)
         Process.daemon(true) unless verbose
         Cache.write_pid_file do
@@ -33,9 +33,10 @@ module RuboCop
 
       private
 
-      def start_server(port)
-        @server = TCPServer.open('127.0.0.1', port)
-        puts "Server listen on port #{@server.addr[1]}" if verbose
+      def start_server(port:, allow_external_access: false)
+        address = allow_external_access ? '0.0.0.0' : '127.0.0.1'
+        @server = TCPServer.open(address, port)
+        puts "Server listen on #{address}:#{@server.addr[1]}" if verbose
       end
 
       def read_socket(socket)

--- a/lib/rubocop/daemon/version.rb
+++ b/lib/rubocop/daemon/version.rb
@@ -2,6 +2,6 @@
 
 module RuboCop
   module Daemon
-    VERSION = '0.3.2'.freeze
+    VERSION = '0.3.3'.freeze
   end
 end


### PR DESCRIPTION
We're using `rubocop-daemon` inside a Docker container to avoid having to install all dependencies locally. This works pretty well with the slightly modified version of the bash wrapper with just one exception - by default `rubocop-daemon` binds itself to `127.0.0.1` which is only accessible on the same machine and does not work when the port is exposed from Docker to the host.

This PR adds optional `--allow-external-access` flag that binds the TCP socket to `0.0.0.0` making it accessible from the outside.

The speed difference is pretty significant:

```sh
➜  h2 git:(master) ✗ time bin/rubocop-daemon-wrapper app/models/profile.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
bin/rubocop-daemon-wrapper app/models/profile.rb  0.01s user 0.03s system 26% cpu 0.146 total
➜  h2 git:(master) ✗ time docker exec -it e09cfd863588 bin/rubocop-daemon-wrapper app/models/profile.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
docker exec -it e09cfd863588 bin/rubocop-daemon-wrapper app/models/profile.rb  0.11s user 0.06s system 43% cpu 0.401 total
```