### PR TITLE
Fix the VS Code integration instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ In the meantime, you could just override the `rubocop` binary with a symlink to 
 $ which rubocop
 <HOME>/.rvm/gems/ruby-x.y.z/bin/rubocop
 
-# Override rubocop with a symlink to rubocop-daemon-wrapper
-$ ln -fs /usr/local/bin/rubocop-daemon-wrapper $HOME/.rvm/gems/ruby-x.y.z/bin/rubocop
+# Override rubocop with a symlink to rubocop-daemon-wrapper/rubocop
+$ ln -fs /usr/local/bin/rubocop-daemon-wrapper/rubocop $HOME/.rvm/gems/ruby-x.y.z/bin/rubocop
 ```
 
 Or, if you use rbenv:
@@ -118,8 +118,8 @@ Or, if you use rbenv:
 $ rbenv which rubocop
 <HOME>/.rbenv/versions/x.y.z/bin/rubocop
 
-# Override rubocop with a symlink to rubocop-daemon-wrapper
-$ ln -fs /usr/local/bin/rubocop-daemon-wrapper $HOME/.rbenv/versions/x.y.z/bin/rubocop
+# Override rubocop with a symlink to rubocop-daemon-wrapper/rubocop
+$ ln -fs /usr/local/bin/rubocop-daemon-wrapper/rubocop $HOME/.rbenv/versions/x.y.z/bin/rubocop
 ```
 
 Now VS Code will use the `rubocop-daemon-wrapper` script, and `formatOnSave` should be much faster (~150ms instead of 3-5 seconds).


### PR DESCRIPTION
It looks like at some point in history:
https://github.com/fohte/rubocop-daemon/commit/5719b6fdeeec5e6baa6ed4262e64532bc33354a9

... the executable bash script in the README was changed
from `/usr/local/bin/rubocop-daemon-wrapper`
to `/usr/local/bin/rubocop-daemon-wrapper/rubocop`

Hence, the VS Code integration instructions were not up to date.
See: https://github.com/fohte/rubocop-daemon/issues/7#issuecomment-983358054

This fixes the symlinks that were broken after the README update.