### PR TITLE
Auto-start and auto-restart gracefully

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,7 @@
 AllCops:
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.6
+  SuggestExtensions: false
+  NewCops: enable
 
 Style/FrozenStringLiteralComment:
   EnforcedStyle: always
@@ -16,7 +18,7 @@ Style/TrailingCommaInArrayLiteral:
 Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: consistent_comma
 
-Metrics/LineLength:
+Layout/LineLength:
   Max: 120
 
 Metrics/MethodLength:

--- a/lib/rubocop/daemon.rb
+++ b/lib/rubocop/daemon.rb
@@ -5,6 +5,7 @@ module RuboCop
     TIMEOUT = 20
 
     autoload :VERSION, 'rubocop/daemon/version'
+    autoload :Utils, 'rubocop/daemon/utils'
 
     autoload :CLI, 'rubocop/daemon/cli'
     autoload :Cache, 'rubocop/daemon/cache'

--- a/lib/rubocop/daemon/cache.rb
+++ b/lib/rubocop/daemon/cache.rb
@@ -55,6 +55,10 @@ module RuboCop
           dir.join('version')
         end
 
+        def config_path
+          dir.join('config')
+        end
+
         def pid_running?
           Process.kill(0, pid_path.read.to_i) == 1
         rescue Errno::ESRCH

--- a/lib/rubocop/daemon/cache.rb
+++ b/lib/rubocop/daemon/cache.rb
@@ -51,6 +51,10 @@ module RuboCop
           dir.join('status')
         end
 
+        def version_path
+          dir.join('version')
+        end
+
         def pid_running?
           Process.kill(0, pid_path.read.to_i) == 1
         rescue Errno::ESRCH

--- a/lib/rubocop/daemon/client_command/base.rb
+++ b/lib/rubocop/daemon/client_command/base.rb
@@ -2,6 +2,7 @@
 
 require 'shellwords'
 require 'socket'
+require 'stringio'
 
 module RuboCop
   module Daemon
@@ -16,25 +17,39 @@ module RuboCop
 
         private
 
-        def send_request(command:, args: [], body: '')
+        def send_request(command:, args: [], body: '', output: STDOUT)
           TCPSocket.open('127.0.0.1', Cache.port_path.read) do |socket|
             socket.puts [Cache.token_path.read, Dir.pwd, command, *args].shelljoin
             socket.write body
             socket.close_write
-            STDOUT.write socket.read(4096) until socket.eof?
+            output.write socket.read(4096) until socket.eof?
           end
         end
 
-        def check_running_server
+        def server_running?
           Daemon.running?.tap do |running|
             warn 'rubocop-daemon: server is not running.' unless running
           end
         end
 
-        def ensure_server!
-          return if check_running_server
+        def server_up_to_date?
+          current_versions = StringIO.new
+          send_request(
+            command: 'exec',
+            args: ['--verbose-version', *@argv],
+            output: current_versions,
+          )
+          current_versions.rewind
+          current_versions = current_versions.read.strip
+          server_versions = Cache.version_path.file? ? Cache.version_path.read.strip : nil
+          (server_versions == current_versions).tap do |up_to_date|
+            warn 'rubocop-daemon: server is running an obsolete version' unless up_to_date
+          end
+        end
 
-          ClientCommand::Start.new([]).run
+        def ensure_server!
+          ClientCommand::Start.new([]).run unless server_running?
+          ClientCommand::Restart.new([]).run unless server_up_to_date?
         end
       end
     end

--- a/lib/rubocop/daemon/client_command/base.rb
+++ b/lib/rubocop/daemon/client_command/base.rb
@@ -33,18 +33,17 @@ module RuboCop
         end
 
         def server_up_to_date?
-          current_versions = StringIO.new
-          send_request(
-            command: 'exec',
-            args: ['--verbose-version', *@argv],
-            output: current_versions,
-          )
-          current_versions.rewind
-          current_versions = current_versions.read.strip
-          server_versions = Cache.version_path.file? ? Cache.version_path.read.strip : nil
-          (server_versions == current_versions).tap do |up_to_date|
-            warn 'rubocop-daemon: server is running an obsolete version' unless up_to_date
-          end
+          current_versions = Utils.versions(@argv)
+          server_versions = Cache.version_path.file? ? Cache.version_path.read : nil
+          versions_match = (server_versions == current_versions)
+          warn 'rubocop-daemon: server is running an obsolete version' unless versions_match
+
+          current_config = Utils.config
+          server_config = Cache.config_path.file? ? Cache.config_path.read : nil
+          config_match = (server_config == current_config)
+          warn 'rubocop-daemon: server is running an obsolete config' unless config_match
+
+          versions_match && config_match
         end
 
         def ensure_server!

--- a/lib/rubocop/daemon/client_command/base.rb
+++ b/lib/rubocop/daemon/client_command/base.rb
@@ -17,12 +17,12 @@ module RuboCop
 
         private
 
-        def send_request(command:, args: [], body: '', output: STDOUT)
+        def send_request(command:, args: [], body: '')
           TCPSocket.open('127.0.0.1', Cache.port_path.read) do |socket|
             socket.puts [Cache.token_path.read, Dir.pwd, command, *args].shelljoin
             socket.write body
             socket.close_write
-            output.write socket.read(4096) until socket.eof?
+            STDOUT.write socket.read(4096) until socket.eof?
           end
         end
 

--- a/lib/rubocop/daemon/client_command/base.rb
+++ b/lib/rubocop/daemon/client_command/base.rb
@@ -35,7 +35,7 @@ module RuboCop
         def server_up_to_date?
           current_versions = Utils.versions(@argv)
           server_versions = Cache.version_path.file? ? Cache.version_path.read : nil
-          versions_match = (server_versions == current_versions)
+          versions_match = server_versions.nil? || (server_versions == current_versions)
           warn 'rubocop-daemon: server is running an obsolete version' unless versions_match
 
           current_config = Utils.config

--- a/lib/rubocop/daemon/client_command/start.rb
+++ b/lib/rubocop/daemon/client_command/start.rb
@@ -19,10 +19,7 @@ module RuboCop
             end
 
             parser.parse(@argv)
-            fork do
-              Server.new(@options.fetch(:no_daemon, false)).start(@options.fetch(:port, 0))
-            end
-            Daemon.wait_for_running_status!(true)
+            Server.new(@options.fetch(:no_daemon, false)).start(@options.fetch(:port, 0))
           end
         end
 

--- a/lib/rubocop/daemon/client_command/start.rb
+++ b/lib/rubocop/daemon/client_command/start.rb
@@ -19,7 +19,10 @@ module RuboCop
             end
 
             parser.parse(@argv)
-            Server.new(@options.fetch(:no_daemon, false)).start(@options.fetch(:port, 0))
+            fork do
+              Server.new(@options.fetch(:no_daemon, false)).start(@options.fetch(:port, 0))
+            end
+            Daemon.wait_for_running_status!(true)
           end
         end
 

--- a/lib/rubocop/daemon/client_command/start.rb
+++ b/lib/rubocop/daemon/client_command/start.rb
@@ -18,6 +18,7 @@ module RuboCop
                 Server.new(verbose).start(@options.fetch(:port, 0))
               else
                 fork do
+                  Process.daemon(true)
                   Server.new(verbose).start(@options.fetch(:port, 0))
                 end
               end

--- a/lib/rubocop/daemon/client_command/stop.rb
+++ b/lib/rubocop/daemon/client_command/stop.rb
@@ -5,7 +5,7 @@ module RuboCop
     module ClientCommand
       class Stop < Base
         def run
-          return unless check_running_server
+          return unless server_running?
 
           parser.parse(@argv)
           send_request(command: 'stop')

--- a/lib/rubocop/daemon/helper.rb
+++ b/lib/rubocop/daemon/helper.rb
@@ -4,9 +4,9 @@ module RuboCop
   module Daemon
     module Helper
       def self.redirect(stdin: $stdin, stdout: $stdout, stderr: $stderr, &_block)
-        old_stdin = $stdin.dup
-        old_stdout = $stdout.dup
-        old_stderr = $stderr.dup
+        old_stdin = $stdin
+        old_stdout = $stdout
+        old_stderr = $stderr
 
         $stdin = stdin
         $stdout = stdout

--- a/lib/rubocop/daemon/server.rb
+++ b/lib/rubocop/daemon/server.rb
@@ -26,10 +26,8 @@ module RuboCop
         start_server(port)
         Cache.write_port_and_token_files(port: @server.addr[1], token: token)
         Cache.version_path.delete if Cache.version_path.file?
-        cli = RuboCop::CLI.new.run([*@args, '--verbose-version'])
-        Cache.version_path.write(
-          RuboCop::Version.version(debug: true, env: cli.instance_variable_get(:@env)).strip
-        )
+        Cache.config_path.delete if Cache.config_path.file?
+        Cache.config_path.write(Utils.config)
         Process.daemon(true) unless verbose
         Cache.write_pid_file do
           read_socket(@server.accept) until @server.closed?

--- a/lib/rubocop/daemon/server.rb
+++ b/lib/rubocop/daemon/server.rb
@@ -28,7 +28,6 @@ module RuboCop
         Cache.version_path.delete if Cache.version_path.file?
         Cache.config_path.delete if Cache.config_path.file?
         Cache.config_path.write(Utils.config)
-        Process.daemon(true) unless verbose
         Cache.write_pid_file do
           read_socket(@server.accept) until @server.closed?
         end

--- a/lib/rubocop/daemon/server.rb
+++ b/lib/rubocop/daemon/server.rb
@@ -25,6 +25,11 @@ module RuboCop
         require 'rubocop'
         start_server(port)
         Cache.write_port_and_token_files(port: @server.addr[1], token: token)
+        Cache.version_path.delete if Cache.version_path.file?
+        cli = RuboCop::CLI.new.run([*@args, '--verbose-version'])
+        Cache.version_path.write(
+          RuboCop::Version.version(debug: true, env: cli.instance_variable_get(:@env)).strip
+        )
         Process.daemon(true) unless verbose
         Cache.write_pid_file do
           read_socket(@server.accept) until @server.closed?

--- a/lib/rubocop/daemon/server_command/exec.rb
+++ b/lib/rubocop/daemon/server_command/exec.rb
@@ -6,6 +6,10 @@ module RuboCop
       class Exec < Base
         def run
           Cache.status_path.delete if Cache.status_path.file?
+          unless Cache.version_path.file?
+            Cache.version_path.write(Utils.versions(@args))
+          end
+
           # RuboCop output is colorized by default where there is a TTY.
           # We must pass the --color option to preserve this behavior.
           @args.unshift('--color') unless %w[--color --no-color].any? { |f| @args.include?(f) }

--- a/lib/rubocop/daemon/server_command/exec.rb
+++ b/lib/rubocop/daemon/server_command/exec.rb
@@ -6,9 +6,7 @@ module RuboCop
       class Exec < Base
         def run
           Cache.status_path.delete if Cache.status_path.file?
-          unless Cache.version_path.file?
-            Cache.version_path.write(Utils.versions(@args))
-          end
+          Cache.version_path.write(Utils.versions(@args)) unless Cache.version_path.file?
 
           # RuboCop output is colorized by default where there is a TTY.
           # We must pass the --color option to preserve this behavior.

--- a/lib/rubocop/daemon/utils.rb
+++ b/lib/rubocop/daemon/utils.rb
@@ -1,0 +1,20 @@
+require 'rubocop'
+require 'stringio'
+
+module RuboCop
+  module Daemon
+    module Utils
+      def self.config
+        RuboCop::ConfigStore.new.for_pwd.signature.strip
+      end
+
+      def self.versions(args)
+        cli = RuboCop::CLI.new
+        Helper.redirect(stdout: StringIO.new) do
+          cli.run([*args, '--verbose-version'])
+        end
+        RuboCop::Version.version(debug: true, env: cli.instance_variable_get(:@env)).strip
+      end
+    end
+  end
+end

--- a/lib/rubocop/daemon/utils.rb
+++ b/lib/rubocop/daemon/utils.rb
@@ -10,6 +10,8 @@ module RuboCop
 
       def self.versions(args)
         cli = RuboCop::CLI.new
+        args = args.dup
+        args.delete('--')
         Helper.redirect(stdout: StringIO.new) do
           cli.run([*args, '--verbose-version'])
         end


### PR DESCRIPTION
Hello,

I've come across 2 friction points while using `rubocop-daemon`:
- the first run of `rubocop-daemon exec` when server is not started auto-starts the server, but does not actually runs rubocop on the files, I change that by forking a subprocess instead of simply calling `Process.daemon` on the main process.
- the server doesn't restart on config changes / version updates, which yields to errors like `Unrecognized cop` on upgrades, I address that by storing the versions and config with which the server started in additional files in the cache