### PR TITLE
improve mac OS netcat call in wrapper

### DIFF
--- a/bin/rubocop-daemon-wrapper
+++ b/bin/rubocop-daemon-wrapper
@@ -20,7 +20,7 @@ if [[ "$OSTYPE" == "linux-gnu" ]]; then
     NETCAT_CMD="nc -N"
   fi
 elif [[ "$OSTYPE" == "darwin"* ]]; then
-  NETCAT_CMD="nc"
+  NETCAT_CMD="/usr/bin/nc"
 elif [[ "$OSTYPE" == "freebsd"* ]]; then
   # https://www.freebsd.org/cgi/man.cgi?query=netcat&manpath=SuSE+Linux/i386+11.3
   NETCAT_CMD="nc"


### PR DESCRIPTION
with Mac OS use `/usr/bin/nc` instead of barebones `nc` 
this fixes an issue when the homebrew version of Netcat is used, as pointed out in #18 